### PR TITLE
docs: add legal disclaimer to README (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,28 @@ This runs markdown, YAML, spell check, and shell script linters in sequence.
 Add any new project-specific words to `project-words.txt` (one word per line)
 to suppress false positives from the spell checker.
 
+## Disclaimer
+
+This demo tracker is provided **for documentation and educational purposes
+only**. It is intended to demonstrate how to deploy and operate the
+[Torrust Tracker](https://github.com/torrust/torrust-tracker), and not to
+provide a persistent or general-purpose public tracking service.
+
+This software is provided solely for lawful purposes. Users must ensure
+compliance with all applicable laws and regulations regarding copyright and
+intellectual property. The Torrust organization and its contributors do not
+condone or support the use of this tracker for any illegal activities, including
+but not limited to the distribution of copyrighted, protected, or otherwise
+illegal content.
+
+By using this tracker, you agree to use it responsibly and in compliance with
+all applicable legal requirements. Misuse of this tracker for illegal purposes
+may lead to legal consequences, for which the Torrust organization and its
+contributors are not liable.
+
+**Tracker data (peer lists, announce history) may be reset at any time without
+notice.**
+
 ## Contributing
 
 Feedback, issues, and pull requests are welcome. If you spot a problem with the


### PR DESCRIPTION
## Summary

Adds a `## Disclaimer` section to `README.md` to protect the Torrust Org and contributors from legal actions related to misuse of the public demo tracker.

The disclaimer:
- Makes clear the demo is for documentation and educational purposes only.
- States users must comply with all applicable laws.
- States the Torrust Org and contributors are not liable for misuse.
- Informs users that tracker data may be reset at any time.

The text is modelled on the existing disclaimer in [torrust/torrust-index-gui](https://github.com/torrust/torrust-index-gui).

Refs: #11

## Checklist

- [x] `README.md` contains a visible `## Disclaimer` section.
- [x] Passes markdown linter (`npx markdownlint-cli2 "**/*.md"`).
- [x] Passes spell checker (`npx cspell --no-progress`).
- [ ] Follow-up issue for legal review to be opened.